### PR TITLE
fix: refactor widget context and simplify clone settings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,11 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 import type { ColorLevel } from "./colors.js";
 import { COLOR_LEVEL_VALUES, normalizeColor } from "./colors.js";
-import { DEFAULT_EXTENSION_STATUS_ROW, normalizeExtensionStatusRow } from "./extension-statuses.js";
+import {
+  cloneExtensionStatusRow,
+  DEFAULT_EXTENSION_STATUS_ROW,
+  normalizeExtensionStatusRow,
+} from "./extension-statuses.js";
 import {
   PRESET_DEFINITIONS,
   type Preset,
@@ -16,6 +20,7 @@ import { SEPARATOR_VALUES, type SeparatorStyle } from "./separators.js";
 import type {
   IconMode,
   StatuslineConfig,
+  StatuslineSettings,
   TerminalOptions,
   TerminalWidthMode,
   WidgetEntry,
@@ -96,17 +101,20 @@ export function normalizeConfig(input: unknown): StatuslineConfig {
   };
 }
 
+export function cloneSettings(settings: StatuslineSettings): StatuslineSettings {
+  return {
+    ...settings,
+    terminal: { ...settings.terminal },
+    extensionStatusRow: cloneExtensionStatusRow(settings.extensionStatusRow),
+  };
+}
+
 export function cloneConfig(config: StatuslineConfig): StatuslineConfig {
   return {
-    ...config,
+    ...cloneSettings(config),
     lines: config.lines.map((line) =>
       line.map((widget) => ({ ...widget, options: { ...widget.options } })),
     ),
-    terminal: { ...config.terminal },
-    extensionStatusRow: {
-      hiddenKeys: [...config.extensionStatusRow.hiddenKeys],
-      knownKeys: [...config.extensionStatusRow.knownKeys],
-    },
   };
 }
 

--- a/src/extension-statuses.ts
+++ b/src/extension-statuses.ts
@@ -83,7 +83,7 @@ export function normalizeExtensionStatusRow(value: unknown): ExtensionStatusRowC
   };
 }
 
-function cloneExtensionStatusRow(value: ExtensionStatusRowConfig): ExtensionStatusRowConfig {
+export function cloneExtensionStatusRow(value: ExtensionStatusRowConfig): ExtensionStatusRowConfig {
   return {
     hiddenKeys: [...value.hiddenKeys],
     knownKeys: [...value.knownKeys],

--- a/src/ui/option-edit.ts
+++ b/src/ui/option-edit.ts
@@ -6,17 +6,13 @@ import type { OptionField } from "./model.js";
 
 type OptionFieldApplyResult = "changed" | "unchanged" | WidgetEditAction;
 
-type OptionFieldEdit =
-  | { kind: "cycle"; delta: number }
-  | { kind: "appendText"; text: string }
-  | { kind: "deleteText" };
+type OptionFieldEdit = { kind: "appendText"; text: string } | { kind: "deleteText" };
 
 export function applyOptionFieldEdit(
   widget: Widget,
   field: OptionField,
   edit: OptionFieldEdit,
 ): OptionFieldApplyResult {
-  if (edit.kind === "cycle") return applyOptionField(widget, field, edit.delta);
   if (field.kind !== "text") return "unchanged";
   if (edit.kind === "appendText") {
     widget.update({ [field.id]: getTextField(widget, field.id) + edit.text });

--- a/src/widgets/context.ts
+++ b/src/widgets/context.ts
@@ -1,5 +1,5 @@
-import type { StatuslineData } from "../types.js";
 import type { RenderStatuslineOptions } from "../render.js";
+import type { StatuslineData } from "../types.js";
 import type {
   BaseWidgetContext,
   WidgetContext,
@@ -7,69 +7,21 @@ import type {
   WidgetDependencyValues,
 } from "./types.js";
 
-export const dependencyResolvers = {
-  cwd: (data) => {
-    return data.cwd;
-  },
-  model: (data) => {
-    return data.model;
-  },
-  provider: (data) => {
-    return data.provider;
-  },
-  sessionName: (data) => {
-    return data.sessionName;
-  },
-  sessionId: (data) => {
-    return data.sessionId;
-  },
-  thinkingLevel: (data) => {
-    return data.thinkingLevel;
-  },
-  textVerbosity: (data) => {
-    return data.textVerbosity;
-  },
-  metrics: (data) => {
-    return data.metrics;
-  },
-  usingSubscription: (data) => {
-    return data.usingSubscription;
-  },
-  git: (data) => {
-    return data.git;
-  },
-  activeToolCount: (data) => {
-    return data.activeToolCount;
-  },
-  contextTokens: (data) => {
-    return data.contextTokens;
-  },
-  contextMaxTokens: (data) => {
-    return data.contextMaxTokens;
-  },
-  eventWidgets: (data) => {
-    return data.eventWidgets;
-  },
-  getExtensionStatuses: (_data, options) => {
-    return options.getExtensionStatuses;
-  },
-} satisfies {
-  [K in WidgetDependency]: (
-    data: StatuslineData,
-    options: RenderStatuslineOptions,
-  ) => WidgetDependencyValues[K];
-};
-
 export function contextForDependencies<const TDeps extends readonly WidgetDependency[]>(
   baseCtx: BaseWidgetContext,
   dependencies: TDeps,
   data: StatuslineData,
   options: RenderStatuslineOptions,
 ): WidgetContext<TDeps> {
+  // getExtensionStatuses is read live from options, never snapshotted into data.
+  const source: WidgetDependencyValues = {
+    ...data,
+    getExtensionStatuses: options.getExtensionStatuses,
+  };
   const output: BaseWidgetContext & Partial<WidgetDependencyValues> = { ...baseCtx };
   const writableOutput = output as BaseWidgetContext & Partial<Record<WidgetDependency, unknown>>;
   for (const dependency of dependencies) {
-    writableOutput[dependency] = dependencyResolvers[dependency](data, options);
+    writableOutput[dependency] = source[dependency];
   }
   // TODO(widget-spec): remove this cast if TypeScript gains better support for dynamic object construction.
   return output as WidgetContext<TDeps>;

--- a/src/widgets/store.ts
+++ b/src/widgets/store.ts
@@ -1,3 +1,4 @@
+import { cloneSettings } from "../config.js";
 import type { StatuslineConfig, StatuslineSettings } from "../types.js";
 import { registry } from "./registry.js";
 import type { Widget } from "./types.js";
@@ -9,9 +10,10 @@ export class WidgetStore {
   ) {}
 
   static fromConfig(config: StatuslineConfig): WidgetStore {
+    const { lines, ...settings } = config;
     return new WidgetStore(
-      cloneSettings(config),
-      config.lines.map((line) => line.map((entry) => registry.hydrateWidget(entry))),
+      cloneSettings(settings),
+      lines.map((line) => line.map((entry) => registry.hydrateWidget(entry))),
     );
   }
 
@@ -21,19 +23,4 @@ export class WidgetStore {
       lines: this.lines.map((line) => line.map((widget) => widget.toEntry())),
     };
   }
-}
-
-function cloneSettings(settings: StatuslineSettings): StatuslineSettings {
-  const { lines: _lines, ...settingsOnly } = settings as StatuslineSettings & {
-    lines?: unknown;
-  };
-
-  return {
-    ...settingsOnly,
-    terminal: { ...settings.terminal },
-    extensionStatusRow: {
-      hiddenKeys: [...settings.extensionStatusRow.hiddenKeys],
-      knownKeys: [...settings.extensionStatusRow.knownKeys],
-    },
-  };
 }

--- a/test/render/context.test.ts
+++ b/test/render/context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { contextForDependencies, dependencyResolvers } from "../../src/widgets/context.js";
+import { contextForDependencies } from "../../src/widgets/context.js";
 import { registry } from "../../src/widgets/registry.js";
 import type { StatuslineData } from "../../src/types.js";
 import type { BaseWidgetContext, WidgetDependency } from "../../src/widgets/types.js";
@@ -56,7 +56,6 @@ const data: StatuslineData = {
 
 describe("widget dependency context", () => {
   it("covers every dependency used by registered specs", () => {
-    const resolverKeys = new Set(Object.keys(dependencyResolvers));
     const usedDependencies = new Set<WidgetDependency>();
 
     for (const spec of registry.specs) {
@@ -65,8 +64,14 @@ describe("widget dependency context", () => {
       }
     }
 
+    const ctx = contextForDependencies(baseCtx, [...usedDependencies], data, {
+      getExtensionStatuses() {
+        return new Map();
+      },
+    });
+
     for (const dependency of usedDependencies) {
-      expect(resolverKeys.has(dependency)).toBe(true);
+      expect(dependency in ctx).toBe(true);
     }
   });
 


### PR DESCRIPTION
- extract shared cloning settings helper
- simplify widget dependency context construction
- remove unused option edit cycle handling
- update tests to verify dependency coverage through the generated context