### PR TITLE
feat: add cache hit rate widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The **Value example** column shows the widget value before labels/icons and colo
 | `Total Tokens` | Total tokens from usage records. | Token format, hide when zero. | `182.4k` |
 | `Cache Read` | Cache-read token total. | Token format, hide when zero. | `120k` |
 | `Cache Write` | Cache-write token total. | Token format, hide when zero. | `12k` |
+| `Cache Hit Rate` | Session or latest turn cache hit percentage. | Source, display style, hide when zero. | `72.4%` |
 | `Context Length` | Current context token estimate/usage. | Token format, conditional colors, hide when zero. | `50k` |
 | `Context %` | Used context percentage. | Conditional colors. | `25%` |
 | `Context Remaining` | Remaining context percentage. | Conditional colors. | `75%` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
   visibleExtensionStatusRowEntries,
 } from "./extension-statuses.js";
 import { EMPTY_GIT_INFO, getGitInfo, hasEnabledGitWidgets, loadGitInfo } from "./git.js";
-import { collectSessionMetrics } from "./metrics.js";
+import { collectSessionMetrics, collectTurnMetrics } from "./metrics.js";
 import { renderStatuslines } from "./render.js";
 import { isRecord, type GitInfo, type StatuslineConfig, type StatuslineData } from "./types.js";
 import { openStatuslineConfigUi } from "./ui.js";
@@ -207,6 +207,7 @@ function collectStatuslineData(
     contextTokens: contextUsage?.tokens ?? undefined,
     contextMaxTokens: contextUsage?.contextWindow,
     metrics: collectSessionMetrics(ctx.sessionManager.getBranch()),
+    turnMetrics: collectTurnMetrics(ctx.sessionManager.getEntries()),
     eventWidgets,
   };
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,4 +1,4 @@
-import { isRecord, type SessionMetrics } from "./types.js";
+import { isRecord, type SessionMetrics, type TurnMetrics } from "./types.js";
 
 // Intentionally loose structural projection of the `usage` field on a pi session message entry.
 // Fields stay `unknown` and are validated at runtime (see isRecord usage below) rather than being
@@ -75,6 +75,41 @@ export function collectSessionMetrics(entries: readonly unknown[]): SessionMetri
     metrics.totalTokens +=
       numberOrZero(usage.totalTokens) || input + output + cacheRead + cacheWrite;
     metrics.costUsd += numberOrZero(usage.cost?.total);
+  }
+
+  return metrics;
+}
+
+export function collectTurnMetrics(entries: readonly unknown[]): TurnMetrics {
+  const metrics: TurnMetrics = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+    costUsd: 0,
+  };
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const message = getMessage(entries[index]);
+    if (message?.role !== "assistant") continue;
+
+    const usage = getUsage(message.usage);
+    if (!usage) continue;
+
+    const input = numberOrZero(usage.input);
+    const output = numberOrZero(usage.output);
+    const cacheRead = numberOrZero(usage.cacheRead);
+    const cacheWrite = numberOrZero(usage.cacheWrite);
+
+    metrics.inputTokens = input;
+    metrics.outputTokens = output;
+    metrics.cacheReadTokens = cacheRead;
+    metrics.cacheWriteTokens = cacheWrite;
+    metrics.totalTokens =
+      numberOrZero(usage.totalTokens) || input + output + cacheRead + cacheWrite;
+    metrics.costUsd = numberOrZero(usage.cost?.total);
+    return metrics;
   }
 
   return metrics;

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -316,6 +316,12 @@ const BASE_PRESET_DEFINITIONS = {
           tokenFormatStyle: "compact",
           hideWhenZero: true,
         }),
+        widget("cache-hit-rate", {
+          icon: " CH",
+          fg: "pi:dim",
+          hideWhenZero: true,
+          cacheHitSource: "turn",
+        }),
         widget("cost", {
           icon: " ",
           fg: "pi:dim",

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,15 @@ export interface SessionMetrics {
   compactions: number;
 }
 
+export interface TurnMetrics {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  costUsd: number;
+}
+
 export interface GitInfo {
   branch: string | null;
   sha: string | null;
@@ -108,5 +117,6 @@ export interface StatuslineData {
   contextTokens: number | undefined;
   contextMaxTokens: number | undefined;
   metrics: SessionMetrics;
+  turnMetrics: TurnMetrics;
   eventWidgets: ReadonlyMap<string, string>;
 }

--- a/src/widgets/registry.ts
+++ b/src/widgets/registry.ts
@@ -42,6 +42,7 @@ import { ToolResultsWidget } from "./session/tool-results.js";
 import { TotalMessagesWidget } from "./session/total-messages.js";
 import { TotalTimeWidget } from "./session/total-time.js";
 import { UserMessagesWidget } from "./session/user-messages.js";
+import { CacheHitRateWidget } from "./tokens/cache-hit-rate.js";
 import { CacheReadWidget } from "./tokens/cache-read.js";
 import { CacheWriteWidget } from "./tokens/cache-write.js";
 import { ContextBarWidget } from "./tokens/context-bar.js";
@@ -107,6 +108,7 @@ const WIDGETS = [
   CostWidget,
   CacheReadWidget,
   CacheWriteWidget,
+  CacheHitRateWidget,
   TokensWidget,
   InputTokensWidget,
   OutputTokensWidget,

--- a/src/widgets/tokens/cache-hit-rate.ts
+++ b/src/widgets/tokens/cache-hit-rate.ts
@@ -1,0 +1,55 @@
+import { defineWidget } from "../types.js";
+
+export const CacheHitRateWidget = defineWidget({
+  type: "cache-hit-rate",
+  label: "Cache Hit Rate",
+  category: "Tokens",
+  description: "Session or latest turn cache hit percentage",
+  dependencies: ["metrics", "turnMetrics"],
+  baseOptions: ["raw", "hideWhenZero", "icon"],
+  baseOptionDefaults: {},
+  properties: [
+    {
+      id: "cacheHitSource",
+      label: "Source",
+      kind: "choice",
+      description: "Cache hit rate source",
+      default: "session",
+      options: {
+        choices: [
+          { id: "session", label: "Session", list: "Session" },
+          { id: "turn", label: "Last Turn", list: "Turn" },
+        ],
+        showInWidgets: true,
+        showInColors: true,
+        listProperty: "source",
+      },
+    },
+    {
+      id: "style",
+      label: "Style",
+      kind: "choice",
+      description: "Display style",
+      default: "default",
+      options: {
+        choices: [
+          { id: "default", label: "Default", list: "default" },
+          { id: "compact", label: "Compact", list: "compact" },
+        ],
+        showInWidgets: true,
+        showInColors: false,
+        listProperty: "style",
+      },
+    },
+  ],
+  icons: { emoji: "🎯", nerd: "󰓎", text: "cache hit" },
+  defaultStyle: { fg: "cyan", bg: "default", bold: false },
+  render({ ctx, options, renderWidget }) {
+    const source = options.cacheHitSource === "turn" ? ctx.turnMetrics : ctx.metrics;
+    const { inputTokens, cacheReadTokens, cacheWriteTokens } = source;
+    const promptTokens = inputTokens + cacheReadTokens + cacheWriteTokens;
+    const hitRate = promptTokens > 0 ? (cacheReadTokens / promptTokens) * 100 : 0;
+    if (hitRate === 0 && options.hideWhenZero) return undefined;
+    return renderWidget(`${hitRate.toFixed(options.style === "compact" ? 0 : 1)}%`);
+  },
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -132,6 +132,7 @@ describe("config", () => {
         "tokens",
         "cache-read",
         "cache-write",
+        "cache-hit-rate",
         "cost",
         "context",
         "context-window",
@@ -165,6 +166,7 @@ describe("config", () => {
       "tokens",
       "cache-read",
       "cache-write",
+      "cache-hit-rate",
       "cost",
       "context",
       "context-window",
@@ -201,19 +203,25 @@ describe("config", () => {
       hideWhenZero: true,
     });
     expect(config.lines[1]?.[3]?.options).toMatchObject({
+      icon: " CH",
+      fg: "pi:dim",
+      hideWhenZero: true,
+      cacheHitSource: "turn",
+    });
+    expect(config.lines[1]?.[4]?.options).toMatchObject({
       icon: " ",
       fg: "pi:dim",
       costFormatStyle: "compact",
       showSubscription: true,
     });
-    expect(config.lines[1]?.[4]?.options).toMatchObject({
+    expect(config.lines[1]?.[5]?.options).toMatchObject({
       icon: " ",
       fg: "pi:dim",
       contextConditionalColors: true,
       warningFg: "pi:warning",
       dangerFg: "pi:error",
     });
-    expect(config.lines[1]?.[5]?.options).toMatchObject({
+    expect(config.lines[1]?.[6]?.options).toMatchObject({
       icon: "/",
       fg: "pi:dim",
       contextConditionalColors: true,

--- a/test/helpers/render.ts
+++ b/test/helpers/render.ts
@@ -66,6 +66,14 @@ export function makeStatuslineData(overrides: Partial<StatuslineData> = {}): Sta
       lastTimestampMs: 0,
       compactions: 0,
     },
+    turnMetrics: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+    },
     eventWidgets: new Map(),
     ...overrides,
   };

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { collectSessionMetrics } from "../src/metrics.js";
+import { collectSessionMetrics, collectTurnMetrics } from "../src/metrics.js";
 
 describe("collectSessionMetrics", () => {
   it("collects message counts, usage, cost, and timestamps", () => {
@@ -42,6 +42,48 @@ describe("collectSessionMetrics", () => {
       firstTimestampMs: 1000,
       lastTimestampMs: 4000,
       compactions: 1,
+    });
+  });
+
+  it("collects the latest assistant turn metrics", () => {
+    expect(
+      collectTurnMetrics([
+        {
+          message: {
+            role: "assistant",
+            usage: { input: 10, cacheRead: 20, cacheWrite: 30 },
+          },
+        },
+        { message: { role: "toolResult" } },
+        {
+          message: {
+            role: "assistant",
+            usage: {
+              input: 40,
+              output: 70,
+              cacheRead: 50,
+              cacheWrite: 60,
+              totalTokens: 0,
+              cost: { total: 0.02 },
+            },
+          },
+        },
+      ]),
+    ).toEqual({
+      inputTokens: 40,
+      outputTokens: 70,
+      cacheReadTokens: 50,
+      cacheWriteTokens: 60,
+      totalTokens: 220,
+      costUsd: 0.02,
+    });
+    expect(collectTurnMetrics([{ message: { role: "user" } }])).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
     });
   });
 

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -65,6 +65,14 @@ const data: StatuslineData = {
     lastTimestampMs: 120_000,
     compactions: 0,
   },
+  turnMetrics: {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+    costUsd: 0,
+  },
   eventWidgets: new Map(),
 };
 
@@ -102,10 +110,18 @@ describe("renderStatusline", () => {
       {
         ...data,
         metrics: { ...data.metrics, cacheReadTokens: 533_000, cacheWriteTokens: 1200 },
+        turnMetrics: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 300,
+          cacheWriteTokens: 100,
+          totalTokens: 550,
+          costUsd: 0.01,
+        },
       },
       120,
     );
-    expect(linesWithCache[1]).toContain("↑12k ↓6.8k R533k W1.2k $0.123 25%/100k");
+    expect(linesWithCache[1]).toContain("↑12k ↓6.8k R533k W1.2k CH60.0% $0.123 25%/100k");
   });
 
   it("supports pi foreground colors", () => {
@@ -174,6 +190,7 @@ describe("renderStatusline", () => {
             bare("total-tokens"),
             bare("cache-read"),
             bare("cache-write"),
+            bare("cache-hit-rate"),
             bare("context-length"),
             bare("context-bar"),
             bare("cost"),

--- a/test/render/context.test.ts
+++ b/test/render/context.test.ts
@@ -51,6 +51,14 @@ const data: StatuslineData = {
     lastTimestampMs: 10,
     compactions: 11,
   },
+  turnMetrics: {
+    inputTokens: 12,
+    outputTokens: 15,
+    cacheReadTokens: 13,
+    cacheWriteTokens: 14,
+    totalTokens: 54,
+    costUsd: 0.02,
+  },
   eventWidgets: new Map([["flag", "on"]]),
 };
 

--- a/test/widgets/registry.test.ts
+++ b/test/widgets/registry.test.ts
@@ -16,6 +16,7 @@ const VALID_DEPENDENCIES = new Set<WidgetDependency>([
   "thinkingLevel",
   "textVerbosity",
   "metrics",
+  "turnMetrics",
   "usingSubscription",
   "git",
   "activeToolCount",

--- a/test/widgets/tokens/cache-hit-rate.test.ts
+++ b/test/widgets/tokens/cache-hit-rate.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeConfig } from "../../../src/config.js";
+import type { WidgetOptions } from "../../../src/types.js";
+import {
+  fieldsForWidget,
+  formatWidgetColorOptions,
+  formatWidgetOptions,
+} from "../../../src/ui/fields.js";
+import { WidgetInstance } from "../../../src/widgets/instance.js";
+import { registry } from "../../../src/widgets/registry.js";
+import { CacheHitRateWidget } from "../../../src/widgets/tokens/cache-hit-rate.js";
+import type { WidgetContext } from "../../../src/widgets/types.js";
+import { TOKEN_METRICS, TURN_METRICS } from "./fixtures.js";
+
+function cacheHitRate(options: WidgetOptions = {}) {
+  return registry.createWidget("cache-hit-rate", options);
+}
+
+function ctx(overrides: Partial<WidgetContext<["metrics", "turnMetrics"]>> = {}) {
+  return {
+    iconMode: "text",
+    minimalist: false,
+    colorLevel: "none",
+    metrics: TOKEN_METRICS,
+    turnMetrics: TURN_METRICS,
+    ...overrides,
+  } satisfies WidgetContext<["metrics", "turnMetrics"]>;
+}
+
+describe("CacheHitRateWidget", () => {
+  it("owns metadata and default options", () => {
+    const widget = cacheHitRate();
+    expect(widget).toBeInstanceOf(WidgetInstance);
+    expect(registry.spec(widget.type)).toBe(CacheHitRateWidget);
+    expect(CacheHitRateWidget.label).toBe("Cache Hit Rate");
+    expect(CacheHitRateWidget.dependencies).toEqual(["metrics", "turnMetrics"]);
+    expect(CacheHitRateWidget.icons).toEqual({ emoji: "🎯", nerd: "󰓎", text: "cache hit" });
+    expect(CacheHitRateWidget.defaultStyle).toEqual({ fg: "cyan", bg: "default", bold: false });
+    expect(CacheHitRateWidget.baseOptionDefaults).toEqual({});
+    expect(registry.createEntry("cache-hit-rate").options).toEqual({
+      raw: false,
+      hideWhenZero: false,
+      icon: "",
+      cacheHitSource: "session",
+      style: "default",
+      fg: "cyan",
+      bg: "default",
+      bold: false,
+    });
+  });
+
+  it("renders session and last turn cache hit rates", () => {
+    const metrics = {
+      ...TOKEN_METRICS,
+      inputTokens: 100,
+      cacheReadTokens: 300,
+      cacheWriteTokens: 100,
+    };
+    const turnMetrics = {
+      ...TURN_METRICS,
+      inputTokens: 50,
+      cacheReadTokens: 400,
+      cacheWriteTokens: 50,
+    };
+
+    expect(cacheHitRate().render(ctx({ metrics, turnMetrics }))).toBe("cache hit 60.0%");
+    expect(cacheHitRate({ icon: "CH" }).render(ctx({ metrics, turnMetrics }))).toBe("CH60.0%");
+    expect(cacheHitRate({ raw: true }).render(ctx({ metrics, turnMetrics }))).toBe("60.0%");
+    expect(
+      cacheHitRate({ raw: true, cacheHitSource: "turn" }).render(ctx({ metrics, turnMetrics })),
+    ).toBe("80.0%");
+    expect(
+      cacheHitRate({ raw: true, cacheHitSource: "turn", style: "compact" }).render(
+        ctx({ metrics, turnMetrics }),
+      ),
+    ).toBe("80%");
+  });
+
+  it("renders zero and optionally hides it", () => {
+    const metrics = {
+      ...TOKEN_METRICS,
+      inputTokens: 100,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+
+    expect(cacheHitRate().render(ctx({ metrics }))).toBe("cache hit 0.0%");
+    expect(cacheHitRate({ hideWhenZero: true }).render(ctx({ metrics }))).toBeUndefined();
+  });
+
+  it("exposes metadata fields and summaries", () => {
+    expect(fieldsForWidget(cacheHitRate()).map((field) => field.id)).toEqual([
+      "enabled",
+      "raw",
+      "hideWhenZero",
+      "icon",
+      "cacheHitSource",
+      "style",
+    ]);
+    expect(formatWidgetOptions(cacheHitRate())).toBe("");
+    expect(formatWidgetOptions(cacheHitRate({ cacheHitSource: "turn" }))).toBe("source=Turn");
+    expect(formatWidgetOptions(cacheHitRate({ style: "compact" }))).toBe("style=compact");
+    expect(formatWidgetOptions(cacheHitRate({ hideWhenZero: true }))).toBe("hide-zero");
+    expect(formatWidgetOptions(cacheHitRate({ raw: true, icon: "CH" }))).toBe("raw • icon='CH'");
+    expect(formatWidgetColorOptions(cacheHitRate({ cacheHitSource: "turn" }))).toBe("source=Turn");
+    expect(formatWidgetColorOptions(cacheHitRate({ fg: "red", bold: true }))).toBe("fg=Red • bold");
+  });
+
+  it("normalizes config through metadata", () => {
+    expect(
+      normalizeConfig({
+        lines: [
+          [
+            {
+              type: "cache-hit-rate",
+              options: {
+                raw: true,
+                hideWhenZero: true,
+                cacheHitSource: "turn",
+                style: "compact",
+              },
+            },
+          ],
+        ],
+      }).lines[0]?.[0]?.options,
+    ).toMatchObject({
+      raw: true,
+      hideWhenZero: true,
+      cacheHitSource: "turn",
+      style: "compact",
+    });
+    expect(
+      normalizeConfig({
+        lines: [
+          [
+            {
+              type: "cache-hit-rate",
+              options: {
+                hideWhenZero: "yes",
+                cacheHitSource: "message",
+                style: "wide",
+                extra: true,
+              },
+            },
+          ],
+        ],
+      }).lines[0]?.[0]?.options,
+    ).toEqual({
+      raw: false,
+      hideWhenZero: false,
+      icon: "",
+      fg: "cyan",
+      bg: "default",
+      bold: false,
+      cacheHitSource: "session",
+      style: "default",
+    });
+  });
+});

--- a/test/widgets/tokens/fixtures.ts
+++ b/test/widgets/tokens/fixtures.ts
@@ -1,4 +1,4 @@
-import type { SessionMetrics } from "../../../src/types.js";
+import type { SessionMetrics, TurnMetrics } from "../../../src/types.js";
 
 export const TOKEN_METRICS: SessionMetrics = {
   inputTokens: 12_345,
@@ -13,4 +13,13 @@ export const TOKEN_METRICS: SessionMetrics = {
   firstTimestampMs: 0,
   lastTimestampMs: 120_000,
   compactions: 0,
+};
+
+export const TURN_METRICS: TurnMetrics = {
+  inputTokens: 100,
+  outputTokens: 50,
+  cacheReadTokens: 300,
+  cacheWriteTokens: 100,
+  totalTokens: 550,
+  costUsd: 0.01,
 };


### PR DESCRIPTION
## Summary

- add a configurable Cache Hit Rate widget with session and latest-turn sources
- support default and compact percentage formatting plus zero hiding
- track normalized latest-turn usage metrics for provider-independent calculations
- add the latest-turn cache hit rate to the `pi-footer` preset so it matches pi's built-in footer

## Testing

- `npm run typecheck`
- `npm run fmt:check`
- `npm run lint`
- `npm run test`

Closes #47
