### PR TITLE
build: publish compiled extension entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
   ],
   "pi": {
     "extensions": [
-      "./src/index.ts"
+      "./dist/index.js"
     ],
     "video": "https://raw.githubusercontent.com/wobondar/pi-footer/main/assets/demo-video.mp4",
     "image": "https://raw.githubusercontent.com/wobondar/pi-footer/main/assets/demo-teaser.gif"
   },
   "files": [
-    "src/",
+    "dist/",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"
@@ -47,7 +47,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
-    "prepublishOnly": "npm run typecheck && npm run fmt:check && npm run lint && npm run test"
+    "prepublishOnly": "npm run build && npm run typecheck && npm run fmt:check && npm run lint && npm run test",
+    "build": "tsc -p tsconfig.build.json"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules/**", "test/**"]
+}


### PR DESCRIPTION
## Summary
Publish the extension as compiled JavaScript instead of asking Pi to JIT-load the raw TypeScript source tree at startup.

- add `tsconfig.build.json` and `npm run build`
- publish `dist/` instead of `src/`
- point the Pi manifest to `./dist/index.js`
- build before the existing `prepublishOnly` checks

## Local benchmark
Using `PI_TIMING=1 pi -ne -e <entry> --no-session -p ...` against this checkout:

| Entry | Import runs | Average |
| --- | --- | --- |
| `src/index.ts` | 4.855s, 4.646s, 4.644s | 4.72s |
| `dist/index.js` | 1.925s, 1.727s, 1.776s | 1.81s |

That is a ~62% reduction in the footer extension's import time in this environment.

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run fmt:check`
- `npm run lint:check`
- `npm run test` (507 passing)
- `npm pack --dry-run` confirms `dist/` is included

Related Pi discussion and timing report: https://github.com/earendil-works/pi/issues/4254