### PR TITLE
feat: add per-second option to speed widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ The **Value example** column shows the widget value before labels/icons and colo
 | `Context Remaining` | Remaining context percentage. | Conditional colors. | `75%` |
 | `Context Bar` | Progress bar plus context usage. | Display: default, short, short-only, medium; token format; conditional colors. | `[████████░░░░░░░░░░░░░░░░░░░░░░░░] 50k/200k (25%)` |
 | `Session Cost` | Estimated session cost. | Cost format, show subscription marker. | `$0.1234` |
-| `Input Speed` | Average input tokens per minute across transcript span. | Token format, hide when zero. | `20.1k/min` |
-| `Output Speed` | Average output tokens per minute across transcript span. | Token format, hide when zero. | `1.1k/min` |
-| `Total Speed` | Average total tokens per minute across transcript span. | Token format, hide when zero. | `21.2k/min` |
+| `Input Speed` | Average input token speed across transcript span. | Token format, speed unit (per minute/second), hide when zero. | `20.1k/min` |
+| `Output Speed` | Average output token speed across transcript span. | Token format, speed unit (per minute/second), hide when zero. | `1.1k/min` |
+| `Total Speed` | Average total token speed across transcript span. | Token format, speed unit (per minute/second), hide when zero. | `21.2k/min` |
 
 ### Session widgets
 

--- a/src/widgets/tokens/input-speed.ts
+++ b/src/widgets/tokens/input-speed.ts
@@ -1,25 +1,34 @@
 import { defineWidget } from "../types.js";
-import { formatTokenSpeed, tokenFormatStyleProperty } from "../utils/token-format.js";
+import {
+  formatTokenSpeed,
+  speedUnitProperty,
+  speedUnitSuffix,
+  tokenFormatStyleProperty,
+} from "../utils/token-format.js";
 
 export const InputSpeedWidget = defineWidget({
   type: "input-speed",
   label: "Input Speed",
   category: "Tokens",
-  description: "Average input tokens per minute",
+  description: "Average input token speed",
   dependencies: ["metrics"],
   baseOptions: ["raw", "hideWhenZero", "icon"],
   baseOptionDefaults: {},
-  properties: [tokenFormatStyleProperty()],
+  properties: [tokenFormatStyleProperty(), speedUnitProperty()],
   icons: { emoji: "⏫", nerd: "", text: "in/min" },
   defaultStyle: { fg: "brightMagenta", bg: "default", bold: false },
   render({ ctx, options, renderWidget }) {
-    return renderWidget(
-      formatTokenSpeed(
-        ctx.metrics.inputTokens,
-        ctx.metrics.firstTimestampMs,
-        ctx.metrics.lastTimestampMs,
-        options.tokenFormatStyle,
-      ),
+    const value = formatTokenSpeed(
+      ctx.metrics.inputTokens,
+      ctx.metrics.firstTimestampMs,
+      ctx.metrics.lastTimestampMs,
+      options.tokenFormatStyle,
+      options.speedUnit,
     );
+    // Only the text icon embeds the unit; emoji/nerd glyphs come from the static set.
+    if (ctx.iconMode !== "text") return renderWidget(value);
+    return renderWidget(value, {
+      icons: { emoji: "", nerd: "", text: `in${speedUnitSuffix(options.speedUnit)}` },
+    });
   },
 });

--- a/src/widgets/tokens/output-speed.ts
+++ b/src/widgets/tokens/output-speed.ts
@@ -1,25 +1,34 @@
 import { defineWidget } from "../types.js";
-import { formatTokenSpeed, tokenFormatStyleProperty } from "../utils/token-format.js";
+import {
+  formatTokenSpeed,
+  speedUnitProperty,
+  speedUnitSuffix,
+  tokenFormatStyleProperty,
+} from "../utils/token-format.js";
 
 export const OutputSpeedWidget = defineWidget({
   type: "output-speed",
   label: "Output Speed",
   category: "Tokens",
-  description: "Average output tokens per minute",
+  description: "Average output token speed",
   dependencies: ["metrics"],
   baseOptions: ["raw", "hideWhenZero", "icon"],
   baseOptionDefaults: {},
-  properties: [tokenFormatStyleProperty()],
+  properties: [tokenFormatStyleProperty(), speedUnitProperty()],
   icons: { emoji: "⏬", nerd: "", text: "out/min" },
   defaultStyle: { fg: "brightCyan", bg: "default", bold: false },
   render({ ctx, options, renderWidget }) {
-    return renderWidget(
-      formatTokenSpeed(
-        ctx.metrics.outputTokens,
-        ctx.metrics.firstTimestampMs,
-        ctx.metrics.lastTimestampMs,
-        options.tokenFormatStyle,
-      ),
+    const value = formatTokenSpeed(
+      ctx.metrics.outputTokens,
+      ctx.metrics.firstTimestampMs,
+      ctx.metrics.lastTimestampMs,
+      options.tokenFormatStyle,
+      options.speedUnit,
     );
+    // Only the text icon embeds the unit; emoji/nerd glyphs come from the static set.
+    if (ctx.iconMode !== "text") return renderWidget(value);
+    return renderWidget(value, {
+      icons: { emoji: "", nerd: "", text: `out${speedUnitSuffix(options.speedUnit)}` },
+    });
   },
 });

--- a/src/widgets/tokens/total-speed.ts
+++ b/src/widgets/tokens/total-speed.ts
@@ -1,25 +1,34 @@
 import { defineWidget } from "../types.js";
-import { formatTokenSpeed, tokenFormatStyleProperty } from "../utils/token-format.js";
+import {
+  formatTokenSpeed,
+  speedUnitProperty,
+  speedUnitSuffix,
+  tokenFormatStyleProperty,
+} from "../utils/token-format.js";
 
 export const TotalSpeedWidget = defineWidget({
   type: "total-speed",
   label: "Total Speed",
   category: "Tokens",
-  description: "Average total tokens per minute",
+  description: "Average total token speed",
   dependencies: ["metrics"],
   baseOptions: ["raw", "hideWhenZero", "icon"],
   baseOptionDefaults: {},
-  properties: [tokenFormatStyleProperty()],
+  properties: [tokenFormatStyleProperty(), speedUnitProperty()],
   icons: { emoji: "⚡", nerd: "↕", text: "tok/min" },
   defaultStyle: { fg: "brightGreen", bg: "default", bold: false },
   render({ ctx, options, renderWidget }) {
-    return renderWidget(
-      formatTokenSpeed(
-        ctx.metrics.totalTokens,
-        ctx.metrics.firstTimestampMs,
-        ctx.metrics.lastTimestampMs,
-        options.tokenFormatStyle,
-      ),
+    const value = formatTokenSpeed(
+      ctx.metrics.totalTokens,
+      ctx.metrics.firstTimestampMs,
+      ctx.metrics.lastTimestampMs,
+      options.tokenFormatStyle,
+      options.speedUnit,
     );
+    // Only the text icon embeds the unit; emoji/nerd glyphs come from the static set.
+    if (ctx.iconMode !== "text") return renderWidget(value);
+    return renderWidget(value, {
+      icons: { emoji: "", nerd: "", text: `tok${speedUnitSuffix(options.speedUnit)}` },
+    });
   },
 });

--- a/src/widgets/utils/token-format.ts
+++ b/src/widgets/utils/token-format.ts
@@ -42,12 +42,46 @@ export function formatTokenCount(value: number, style: TokenFormatStyle) {
   return TOKEN_FORMAT_STYLES[style].format(value);
 }
 
+const SPEED_UNITS = {
+  "per-minute": {
+    label: "Per minute",
+    list: "Per minute",
+    suffix: "/min",
+    perMs: 60_000,
+  },
+  "per-second": {
+    label: "Per second",
+    list: "Per second",
+    suffix: "/s",
+    perMs: 1_000,
+  },
+} as const;
+
+export type SpeedUnit = keyof typeof SPEED_UNITS;
+
+const SPEED_UNIT_VALUES = Object.keys(SPEED_UNITS) as SpeedUnit[];
+
+const SPEED_UNIT_CHOICES = SPEED_UNIT_VALUES.map((unit) => ({
+  id: unit,
+  label: SPEED_UNITS[unit].label,
+  list: SPEED_UNITS[unit].list,
+}));
+
+// Never divide by less than one second of span so a single early sample cannot inflate the rate.
+const MIN_SPAN_MS = 1_000;
+
+export function speedUnitSuffix(speedUnit: SpeedUnit) {
+  return SPEED_UNITS[speedUnit].suffix;
+}
+
 export function formatTokenSpeed(
   tokens: number,
   first: number | undefined,
   last: number | undefined,
   tokenFormatStyle: TokenFormatStyle,
+  speedUnit: SpeedUnit = "per-minute",
 ) {
+  const unit = SPEED_UNITS[speedUnit];
   if (
     first === undefined ||
     last === undefined ||
@@ -55,10 +89,27 @@ export function formatTokenSpeed(
     !Number.isFinite(last) ||
     last <= first
   ) {
-    return "0/min";
+    return `0${unit.suffix}`;
   }
-  const minutes = Math.max((last - first) / 60000, 1 / 60);
-  return `${formatTokenCount(Math.round(tokens / minutes), tokenFormatStyle)}/min`;
+  const spanMs = Math.max(last - first, MIN_SPAN_MS);
+  const rate = Math.round((tokens * unit.perMs) / spanMs);
+  return `${formatTokenCount(rate, tokenFormatStyle)}${unit.suffix}`;
+}
+
+export function speedUnitProperty() {
+  return {
+    id: "speedUnit",
+    label: "Speed unit",
+    kind: "choice",
+    description: "Rate window used for token speed",
+    default: "per-minute",
+    options: {
+      choices: SPEED_UNIT_CHOICES,
+      showInWidgets: true,
+      showInColors: false,
+      listProperty: "rate",
+    },
+  } as const;
 }
 
 export function tokenFormatStyleProperty() {

--- a/test/widgets/tokens/input-speed.test.ts
+++ b/test/widgets/tokens/input-speed.test.ts
@@ -45,6 +45,7 @@ describe("InputSpeedWidget", () => {
       hideWhenZero: false,
       icon: "",
       tokenFormatStyle: "default",
+      speedUnit: "per-minute",
       fg: "brightMagenta",
       bg: "default",
       bold: false,
@@ -55,6 +56,8 @@ describe("InputSpeedWidget", () => {
     expect(inputSpeed().render(ctx())).toBe("in/min 6.2k/min");
     expect(inputSpeed({ icon: "In: " }).render(ctx())).toBe("In: 6.2k/min");
     expect(inputSpeed({ raw: true }).render(ctx())).toBe("6.2k/min");
+    expect(inputSpeed({ speedUnit: "per-second" }).render(ctx())).toBe("in/s 103/s");
+    expect(inputSpeed({ raw: true, speedUnit: "per-second" }).render(ctx())).toBe("103/s");
     expect(
       inputSpeed({ raw: true, tokenFormatStyle: "compact" }).render(
         ctx({ metrics: { ...TOKEN_METRICS, lastTimestampMs: 60_000 } }),
@@ -98,9 +101,11 @@ describe("InputSpeedWidget", () => {
       "hideWhenZero",
       "icon",
       "tokenFormatStyle",
+      "speedUnit",
     ]);
     expect(formatWidgetOptions(inputSpeed())).toBe("");
     expect(formatWidgetOptions(inputSpeed({ tokenFormatStyle: "compact" }))).toBe("format=Compact");
+    expect(formatWidgetOptions(inputSpeed({ speedUnit: "per-second" }))).toBe("rate=Per second");
     expect(formatWidgetOptions(inputSpeed({ hideWhenZero: true }))).toBe("hide-zero");
     expect(formatWidgetOptions(inputSpeed({ raw: true, icon: "S " }))).toBe("raw • icon='S '");
     expect(formatWidgetColorOptions(inputSpeed({ fg: "red", bold: true }))).toBe("fg=Red • bold");
@@ -131,6 +136,7 @@ describe("InputSpeedWidget", () => {
       bg: "default",
       bold: false,
       tokenFormatStyle: "default",
+      speedUnit: "per-minute",
     });
   });
 });

--- a/test/widgets/tokens/output-speed.test.ts
+++ b/test/widgets/tokens/output-speed.test.ts
@@ -45,6 +45,7 @@ describe("OutputSpeedWidget", () => {
       hideWhenZero: false,
       icon: "",
       tokenFormatStyle: "default",
+      speedUnit: "per-minute",
       fg: "brightCyan",
       bg: "default",
       bold: false,
@@ -55,6 +56,8 @@ describe("OutputSpeedWidget", () => {
     expect(outputSpeed().render(ctx())).toBe("out/min 3.4k/min");
     expect(outputSpeed({ icon: "Out: " }).render(ctx())).toBe("Out: 3.4k/min");
     expect(outputSpeed({ raw: true }).render(ctx())).toBe("3.4k/min");
+    expect(outputSpeed({ speedUnit: "per-second" }).render(ctx())).toBe("out/s 57/s");
+    expect(outputSpeed({ raw: true, speedUnit: "per-second" }).render(ctx())).toBe("57/s");
     expect(
       outputSpeed({ raw: true, tokenFormatStyle: "compact" }).render(
         ctx({ metrics: { ...TOKEN_METRICS, outputTokens: 12_345, lastTimestampMs: 60_000 } }),
@@ -98,11 +101,13 @@ describe("OutputSpeedWidget", () => {
       "hideWhenZero",
       "icon",
       "tokenFormatStyle",
+      "speedUnit",
     ]);
     expect(formatWidgetOptions(outputSpeed())).toBe("");
     expect(formatWidgetOptions(outputSpeed({ tokenFormatStyle: "compact" }))).toBe(
       "format=Compact",
     );
+    expect(formatWidgetOptions(outputSpeed({ speedUnit: "per-second" }))).toBe("rate=Per second");
     expect(formatWidgetOptions(outputSpeed({ hideWhenZero: true }))).toBe("hide-zero");
     expect(formatWidgetOptions(outputSpeed({ raw: true, icon: "S " }))).toBe("raw • icon='S '");
     expect(formatWidgetColorOptions(outputSpeed({ fg: "red", bold: true }))).toBe("fg=Red • bold");
@@ -133,6 +138,7 @@ describe("OutputSpeedWidget", () => {
       bg: "default",
       bold: false,
       tokenFormatStyle: "default",
+      speedUnit: "per-minute",
     });
   });
 });

--- a/test/widgets/tokens/total-speed.test.ts
+++ b/test/widgets/tokens/total-speed.test.ts
@@ -45,6 +45,7 @@ describe("TotalSpeedWidget", () => {
       hideWhenZero: false,
       icon: "",
       tokenFormatStyle: "default",
+      speedUnit: "per-minute",
       fg: "brightGreen",
       bg: "default",
       bold: false,
@@ -55,6 +56,8 @@ describe("TotalSpeedWidget", () => {
     expect(totalSpeed().render(ctx())).toBe("tok/min 9.6k/min");
     expect(totalSpeed({ icon: "Total: " }).render(ctx())).toBe("Total: 9.6k/min");
     expect(totalSpeed({ raw: true }).render(ctx())).toBe("9.6k/min");
+    expect(totalSpeed({ speedUnit: "per-second" }).render(ctx())).toBe("tok/s 159/s");
+    expect(totalSpeed({ raw: true, speedUnit: "per-second" }).render(ctx())).toBe("159/s");
     expect(
       totalSpeed({ raw: true, tokenFormatStyle: "compact" }).render(
         ctx({ metrics: { ...TOKEN_METRICS, totalTokens: 12_345, lastTimestampMs: 60_000 } }),
@@ -98,9 +101,11 @@ describe("TotalSpeedWidget", () => {
       "hideWhenZero",
       "icon",
       "tokenFormatStyle",
+      "speedUnit",
     ]);
     expect(formatWidgetOptions(totalSpeed())).toBe("");
     expect(formatWidgetOptions(totalSpeed({ tokenFormatStyle: "compact" }))).toBe("format=Compact");
+    expect(formatWidgetOptions(totalSpeed({ speedUnit: "per-second" }))).toBe("rate=Per second");
     expect(formatWidgetOptions(totalSpeed({ hideWhenZero: true }))).toBe("hide-zero");
     expect(formatWidgetOptions(totalSpeed({ raw: true, icon: "S " }))).toBe("raw • icon='S '");
     expect(formatWidgetColorOptions(totalSpeed({ fg: "red", bold: true }))).toBe("fg=Red • bold");
@@ -131,6 +136,7 @@ describe("TotalSpeedWidget", () => {
       bg: "default",
       bold: false,
       tokenFormatStyle: "default",
+      speedUnit: "per-minute",
     });
   });
 });


### PR DESCRIPTION
## What

Adds a **Speed unit** option (per minute / per second) to the **Input Speed**, **Output Speed**, and **Total Speed** widgets, so token throughput can be displayed as `tk/s` instead of `tk/min`.

- New `speedUnitProperty()` choice, default `per-minute` — existing configs render identically.
- `formatTokenSpeed()` gains a `speedUnit` argument and computes the rate over the same transcript span, flooring the divisor at one second so an early sample can't inflate the number.
- In text icon mode the label reflects the unit (`out/min` vs `out/s`); emoji/nerd glyphs are unchanged.
- Docs and per-widget tests updated (per-minute output is unchanged; per-second cases added).

## Verification

- `npm run typecheck` — clean
- `npm run test` — 507 passed
- `npm run lint:check` — clean
- `npm run fmt:check` — clean
